### PR TITLE
Fix type branding

### DIFF
--- a/src/CalendarTypes.ts
+++ b/src/CalendarTypes.ts
@@ -3,7 +3,7 @@
 // Use of this source code is governed by an MIT-style license that
 // can be found in the LICENSE file distributed with this file.
 
-import { fail } from "./internal";
+import { fail, Brand } from "./internal";
 import { DateLike, toDate } from "./DateLike";
 import { toTimestamp } from "./Timestamp";
 import { EpochMs, toEpochMs } from "./EpochMs";
@@ -29,8 +29,7 @@ export function clampEpochMs(ms: number): EpochMs {
 // --------------------------------------------------------------
 // Day
 
-enum CalendarDayBrand {}
-export type CalendarDay = string & CalendarDayBrand;
+export type CalendarDay = string & Brand<"CalendarDay">;
 
 const CALENDAR_DAY_REGEX = /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
 
@@ -73,8 +72,7 @@ function dayString(x: DateLike): string {
 // --------------------------------------------------------------
 // Month
 
-enum CalendarMonthBrand {}
-export type CalendarMonth = string & CalendarMonthBrand;
+export type CalendarMonth = string & Brand<"CalendarMonth">;
 
 export function isMonth(x: any): x is CalendarMonth {
   return typeof x === "string" && isDay(`${x}-01`);
@@ -97,8 +95,7 @@ export function toUtcMonth(x: DateLike): CalendarMonth {
 // --------------------------------------------------------------
 // Year
 
-enum CalendarYearBrand {}
-export type CalendarYear = string & CalendarYearBrand;
+export type CalendarYear = string & Brand<"CalendarYear">;
 
 export function isYear(x: any): x is CalendarYear {
   return typeof x === "string" && isDay(`${x}-01-01`);

--- a/src/EpochMs.ts
+++ b/src/EpochMs.ts
@@ -4,9 +4,10 @@
 // can be found in the LICENSE file distributed with this file.
 
 import { DateLike } from "./DateLike";
+import { Brand } from "./internal";
 
 // Milliseconds used as duration
-export type DurationMs = number & { _brand_DurationMs: any };
+export type DurationMs = number & Brand<"DurationMs">;
 
 export function isDurationMs(x: any): x is DurationMs {
   return typeof x === "number";
@@ -40,7 +41,7 @@ export function durationMs(spec: DurationSpec): DurationMs {
 }
 
 // Milliseconds since UNIX epoch (like `Date.now()`)
-export type EpochMs = number & { _brand_EpochMs: any };
+export type EpochMs = number & Brand<"EpochMs">;
 
 export function isEpochMs(x: any): x is EpochMs {
   return typeof x === "number";

--- a/src/Timestamp.ts
+++ b/src/Timestamp.ts
@@ -3,11 +3,10 @@
 // Use of this source code is governed by an MIT-style license that
 // can be found in the LICENSE file distributed with this file.
 
-import { fail } from "./internal";
+import { fail, Brand } from "./internal";
 import { DateLike, toDate } from "./DateLike";
 
-enum TimestampBrand {}
-export type Timestamp = string & TimestampBrand;
+export type Timestamp = string & Brand<"Timestamp">;
 
 const TIMESTAMP_REGEX = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}(:[0-9]{2}(\.[0-9]+)?)?Z$/;
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -6,3 +6,14 @@
 export function fail(message: string): never {
   throw Error(message);
 }
+
+export class Brand<K extends string> {
+  // NOTE: This must be protected, not private.  If it's private, the TypeScript
+  // compiler will erase the type of _brand_ from the type declaration (.d.ts)
+  // file.  And without this type, Brand<"foo"> and Brand<"bar"> would be
+  // compatible types!
+  protected _brand_: K;
+  constructor() {
+    fail("Not constructable");
+  }
+}

--- a/test/NomDate.test.ts
+++ b/test/NomDate.test.ts
@@ -9,6 +9,7 @@ import {
   toTimestamp,
   timestampOrNull,
   timestampOrThrow,
+  Timestamp,
 } from "../src/Timestamp";
 import {
   isDurationMs,
@@ -21,6 +22,7 @@ import {
   toEpochMs,
   DurationMs,
   DurationCalc,
+  EpochMs,
 } from "../src/EpochMs";
 import {
   clampEpochMs,
@@ -38,7 +40,61 @@ import {
   toUtcYear,
   MAX_EPOCH_MS,
   MIN_EPOCH_MS,
+  CalendarDay,
+  CalendarMonth,
+  CalendarYear,
 } from "../src/CalendarTypes";
+
+// This interface is only used to make the TypeScript compiler perform various
+// static type checks.
+interface TypeAssertions {
+  // This index signature means that every type below must evaluate to "good".
+  [key: string]: "good";
+
+  ///////////////////////////////////////////////////////////////////
+  // Type assignments that should NOT be valid
+  ///////////////////////////////////////////////////////////////////
+
+  // For example, a CalendarDay cannot be assigned to a CalendarMonth:
+  dayMonth: CalendarDay extends CalendarMonth ? "bad" : "good";
+  dayYear: CalendarDay extends CalendarYear ? "bad" : "good";
+  dayTime: CalendarDay extends Timestamp ? "bad" : "good";
+  monthDay: CalendarMonth extends CalendarDay ? "bad" : "good";
+  yearDay: CalendarYear extends CalendarDay ? "bad" : "good";
+  timeDay: Timestamp extends CalendarDay ? "bad" : "good";
+
+  // A string cannot be assigned to a Calendar* or Timestamp:
+  strDay: string extends CalendarDay ? "bad" : "good";
+  strMonth: string extends CalendarDay ? "bad" : "good";
+  strYear: string extends CalendarDay ? "bad" : "good";
+  strTime: string extends Timestamp ? "bad" : "good";
+
+  // A number cannot be assigned to a millisecond type:
+  numDur: number extends DurationMs ? "bad" : "good";
+  numEpoch: number extends EpochMs ? "bad" : "good";
+
+  // Millisecond and Calendar* types are not compatible:
+  durDay: DurationMs extends CalendarDay ? "bad" : "good";
+  dayDur: CalendarDay extends DurationMs ? "bad" : "good";
+
+  // DurationMs and EpochMs are not compatible:
+  durEpoch: DurationMs extends EpochMs ? "bad" : "good";
+  epochDur: EpochMs extends DurationMs ? "bad" : "good";
+
+  ///////////////////////////////////////////////////////////////////
+  // Type assignments that SHOULD be valid
+  ///////////////////////////////////////////////////////////////////
+
+  // Calendar* and Timestamp types can be used as strings:
+  dayStr: CalendarDay extends string ? "good" : "bad";
+  monthStr: CalendarMonth extends string ? "good" : "bad";
+  yearStr: CalendarYear extends string ? "good" : "bad";
+  timeStr: Timestamp extends string ? "good" : "bad";
+
+  // Time types can be used as numbers:
+  durNum: DurationMs extends number ? "good" : "bad";
+  epochNum: EpochMs extends number ? "good" : "bad";
+}
 
 describe("NomDate", () => {
   const now = new Date(2020, 5 - 1, 16, 14, 47);


### PR DESCRIPTION
The branding of `Calendar*` and `Timestamp` doesn't work correctly:
assignments like this are allowed by the type system:
```
const month: CalendarMonth = toUtcDay("foo");
```

This is because `enum {} & string` is like `number & string`, which
evaluates to `never`.  So we need to find a different way to brand these
types.

This solution, using a class with a protected member variable, is the best
that I've found.  The protected member variable means that no additional
properties are visible on the type (you aren't allowed to access
`month._brand_`).  The main downside is that this introduces an additional
class.  I think it's worth the small code size increase.

Note that the TypeScript error messages are still easy to understand.  For
example, if you try to do this:
```
const duration: DurationMs = toUtcDay("foo");
const month: CalendarMonth = toUtcDay("foo");
```
you get the following errors:
```
test/NomDate.test.ts:99:7 - error TS2322: Type 'CalendarDay' is not assignable to type 'CalendarMonth'.
  Type 'CalendarDay' is not assignable to type 'Brand<"CalendarMonth">'.
    Types of property '_brand_' are incompatible.
      Type '"CalendarDay"' is not assignable to type '"CalendarMonth"'.

99 const month: CalendarMonth = toUtcDay("foo");
         ~~~~~

test/NomDate.test.ts:100:7 - error TS2322: Type 'CalendarDay' is not assignable to type 'DurationMs'.
  Type 'CalendarDay' is not assignable to type 'number'.

100 const duration: DurationMs = toUtcDay("foo");
          ~~~~~~~~
```

Test Plan:
Ran `yarn prepack`.  `NomDate.test.ts` passed.

Used `yarn link` to link this module into `covid-19/server/functions`.
Checked that this generates a type error:
```
const month: CalendarMonth = toUtcDay("foo");
```